### PR TITLE
Scale down letterFrequencies for fewer tiles.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -178,6 +178,18 @@ final letterFrequencies = {
   2: ["J", "K", "Q", "X", "Z"],
 };
 
+Map<int, List<String>> calculateFrequencies(Map<int, List<String>> frequencies, int numtiles) {
+  const poolsize = 144;
+  final divfactor = poolsize ~/ numtiles;
+  var newfrequencies = Map<int, List<String>>();
+  for (var entry in frequencies.entries) {
+    var count = (entry.key / divfactor).ceil();
+    newfrequencies.putIfAbsent(count, () => []);
+    newfrequencies[count]?.addAll(entry.value);
+  }
+  return newfrequencies;
+}
+
 final hiriganaFrequencies = {
   2: "あいうえおかきくけこさしすせそたちつてとはひふへほまみむめもやゆよらりるれろわをん".split(''),
 };
@@ -304,10 +316,11 @@ class _MyHomePageState extends State<MyHomePage> {
   void startGame(Map<int, List<String>> frequencies) {
     this.gameMode = GameMode.starting;
     this.lettersInGame = readNumTilesPerGameFromPrefs();
+    final scaledfrequencies = calculateFrequencies(frequencies, this.lettersInGame);
     this.grid = LetterGrid(15, 15);
     this.gridOffset = Offset.zero;
     this.zoomScale = 1.0;
-    this.letterBag = shuffleTiles(frequencies, this.rng);
+    this.letterBag = shuffleTiles(scaledfrequencies, this.rng);
     this.bagIndex = 0;
     this.rackTiles = [];
     this.gameStopwatch.stop();


### PR DESCRIPTION
Using a pool of 144 letters can lead to a mix of pulled letters that has an odd mix.
For example, since there could always be 3 "V"s in the bag, a short game drawing 36
tiles could draw all 3. Arguably, for a 36 tile game, there should only be one V.

calculateFrequencies() isn't perfect as the new frequencies are calculated by division
and floats get messy. For a 36 tile game, 46 tiles wind up in the bag.